### PR TITLE
Use correct typing in inventory_ui.cpp

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2284,7 +2284,7 @@ drop_locations inventory_iuse_selector::execute()
     }
     drop_locations dropped_pos_and_qty;
 
-    for( const std::pair<const item_location *, int> &use_pair : to_use ) {
+    for( const std::pair<const item_location *const, int> &use_pair : to_use ) {
         dropped_pos_and_qty.push_back( std::make_pair( *use_pair.first, use_pair.second ) );
     }
 


### PR DESCRIPTION
#### Summary

SUMMARY: Build "Build not working currently"

#### Purpose of change

Build isn't working currently, this gets `master` branch back to buildable.

#### Describe the solution

Honestly, I just followed the suggestion from the compiler:
```
src/inventory_ui.cpp:2287:55: error: loop variable 'use_pair' has type 'const std::pair<const item_location *, int> &' but is initialized with type 'std::pair<const item_location *const, int>' resulting in a copy [-Werror,-Wrange-loop-construct]
    for( const std::pair<const item_location *, int> &use_pair : to_use ) {
                                                      ^
src/inventory_ui.cpp:2287:10: note: use non-reference type 'std::pair<const item_location *, int>' to keep the copy or type 'const std::pair<const item_location *const, int> &' to prevent copying
    for( const std::pair<const item_location *, int> &use_pair : to_use ) {
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

#### Describe alternatives you've considered

None

#### Testing

Compiles & launches now

#### Additional context

N/A